### PR TITLE
Fix highlight markup for route URIs

### DIFF
--- a/src/Controllers/RouteController.php
+++ b/src/Controllers/RouteController.php
@@ -34,7 +34,7 @@ class RouteController extends Controller
                 })->implode('&nbsp;');
 
                 $grid->uri()->display(function ($uri) {
-                    return preg_replace('/\{.+?\}/', '<code>$0</span>', $uri);
+                    return preg_replace('/\{.+?\}/', '<code>$0</code>', $uri);
                 })->sortable();
 
                 $grid->name();


### PR DESCRIPTION
## Summary
- fix wrong closing tag used when highlighting route parameters

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684060f62a688323b2da942efea9e126