### PR TITLE
Add PHPUnit tests and config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,11 @@
             "SuperAdmin\\Admin\\Helpers\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "SuperAdmin\\Admin\\Helpers\\Tests\\": "tests/"
+        }
+    },
     "extra": {
         "laravel": {
             "providers": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/ModelCreatorTest.php
+++ b/tests/ModelCreatorTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use SuperAdmin\Admin\Helpers\Scaffold\ModelCreator;
+
+class ModelCreatorTest extends TestCase
+{
+    private function invokeReplaceClass(ModelCreator $creator, &$stub, $name)
+    {
+        $ref = new ReflectionClass(ModelCreator::class);
+        $method = $ref->getMethod('replaceClass');
+        $method->setAccessible(true);
+        $method->invokeArgs($creator, [&$stub, $name]);
+    }
+
+    public function testReplaceClassSubstitutesClassName()
+    {
+        $creator = new ModelCreator('users', 'App\\Models\\User', new stdClass());
+        $stub = 'class DummyClass {}';
+        $this->invokeReplaceClass($creator, $stub, 'App\\Models\\User');
+        $this->assertSame('class User {}', $stub);
+    }
+}

--- a/tests/RouteControllerTest.php
+++ b/tests/RouteControllerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use SuperAdmin\Admin\Helpers\Controllers\RouteController;
+
+class RouteControllerTest extends TestCase
+{
+    private function invokeSortRoutes(RouteController $controller, $column, $routes)
+    {
+        $ref = new ReflectionClass(RouteController::class);
+        $method = $ref->getMethod('sortRoutes');
+        $method->setAccessible(true);
+        return $method->invokeArgs($controller, [$column, $routes]);
+    }
+
+    public function testSortRoutesOrdersByGivenColumn()
+    {
+        $controller = new RouteController();
+
+        $routes = [
+            ['uri' => 'c', 'name' => 'route3'],
+            ['uri' => 'a', 'name' => 'route1'],
+            ['uri' => 'b', 'name' => 'route2'],
+        ];
+
+        $sorted = $this->invokeSortRoutes($controller, 'uri', $routes);
+        $this->assertSame(['a', 'b', 'c'], array_values(array_column($sorted, 'uri')));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,29 @@
+<?php
+spl_autoload_register(function($class){
+    $prefix = 'SuperAdmin\\Admin\\Helpers\\';
+    $baseDir = __DIR__ . '/../src/';
+    if (strncmp($class, $prefix, strlen($prefix)) === 0) {
+        $relative = substr($class, strlen($prefix));
+        $file = $baseDir . str_replace('\\', '/', $relative) . '.php';
+        if (file_exists($file)) {
+            require $file;
+        }
+    }
+});
+
+if (!class_exists('Illuminate\\Routing\\Controller')) {
+    class Illuminate_Routing_Controller {}
+    class_alias('Illuminate_Routing_Controller', 'Illuminate\\Routing\\Controller');
+}
+
+if (!class_exists('Illuminate\\Support\\Arr')) {
+    class Illuminate_Support_Arr {
+        public static function sort($array, callable $callback) {
+            uasort($array, function($a, $b) use ($callback) {
+                return $callback($a) <=> $callback($b);
+            });
+            return $array;
+        }
+    }
+    class_alias('Illuminate_Support_Arr', 'Illuminate\\Support\\Arr');
+}


### PR DESCRIPTION
## Summary
- setup PHPUnit configuration
- add unit tests for RouteController and ModelCreator
- enable autoload-dev in composer.json

## Testing
- `phpunit --configuration phpunit.xml --testdox`

------
https://chatgpt.com/codex/tasks/task_e_68406c93a0b48323a34adaedcae9b195