### PR TITLE
Fix adding relation rows in scaffold

### DIFF
--- a/resources/views/scaffold.blade.php
+++ b/resources/views/scaffold.blade.php
@@ -163,6 +163,9 @@
             handle: ".move-handle"
         });
 
+        // initialize relation count based on existing rows
+        let relation_count = document.querySelectorAll('#model-relations tbody tr').length;
+
         document.getElementById('add-table-field').addEventListener("click",function (event) {
 
             let template = document.getElementById('table-field-tpl').innerHTML;
@@ -183,7 +186,12 @@
         if (document.getElementById('add-model-relation')){
             // not implemented yet :-(
             document.getElementById('add-model-relation').addEventListener("click",function (event) {
-                document.getElementById('model-relations tbody').append(document.getElementById('model-relation-tpl').html().replace(/__index__/g, document.getElementById('model-relations tr').length - 1));
+                let template = document.getElementById('model-relation-tpl').innerHTML;
+                let relationRow = template.replace(/__index__/g, relation_count);
+                let newRow = document.createElement('tr');
+                newRow.innerHTML = relationRow;
+
+                document.querySelector('#model-relations tbody').appendChild(newRow);
 
                 relation_count++;
             });


### PR DESCRIPTION
## Summary
- fix JS to append model relation rows using `innerHTML`
- initialize `relation_count` to avoid undefined errors

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406c9283a88323acde69d3645ade8f