### PR TITLE
Fix closing tag in RouteController

### DIFF
--- a/src/Controllers/RouteController.php
+++ b/src/Controllers/RouteController.php
@@ -34,7 +34,7 @@ class RouteController extends Controller
                 })->implode('&nbsp;');
 
                 $grid->uri()->display(function ($uri) {
-                    return preg_replace('/\{.+?\}/', '<code>$0</span>', $uri);
+                    return preg_replace('/\{.+?\}/', '<code>$0</code>', $uri);
                 })->sortable();
 
                 $grid->name();


### PR DESCRIPTION
## Summary
- ensure the replacement string closes with `</code>`

## Testing
- `python3 - <<'PY'
import re
html = '/admin/user/{id}'
result = re.sub(r'\{.+?\}', '<code>\g<0></code>', html)
print(result)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68406c8ff8148323a646599cf44a6764