### PR TITLE
Fix method name casing

### DIFF
--- a/src/Scaffold/ControllerCreator.php
+++ b/src/Scaffold/ControllerCreator.php
@@ -50,7 +50,7 @@ class ControllerCreator
      */
     public function create($model, $fields)
     {
-        $path = $this->getpath($this->name);
+        $path = $this->getPath($this->name);
 
         if ($this->files->exists($path)) {
             throw new \Exception("Controller [$this->name] already exists!");

--- a/src/Scaffold/ModelCreator.php
+++ b/src/Scaffold/ModelCreator.php
@@ -56,7 +56,7 @@ class ModelCreator
      */
     public function create($keyName = 'id', $timestamps = true, $softDeletes = false)
     {
-        $path = $this->getpath($this->name);
+        $path = $this->getPath($this->name);
 
         if ($this->files->exists($path)) {
             throw new \Exception("Model [$this->name] already exists!");


### PR DESCRIPTION
## Summary
- use `getPath` with correct casing in scaffold creators

## Testing
- `php -l src/Scaffold/ModelCreator.php` *(fails: command not found)*
- `php -l src/Scaffold/ControllerCreator.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406c8eb6d083238422f7bfda26862b